### PR TITLE
Simplified servoctl

### DIFF
--- a/cmd/servoctl/servoctl.go
+++ b/cmd/servoctl/servoctl.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/jacobsa/go-serial/serial"
 	"github.com/knei-knurow/lidar-tools/frames"
@@ -27,7 +26,7 @@ func init() {
 	log.SetPrefix("servoctl: ")
 
 	flag.StringVar(&portName, "port", "/dev/ttyUSB0", "serial communication port")
-	flag.UintVar(&baudRate, "baud", 9600, "port baud rate (bps)")
+	flag.UintVar(&baudRate, "baud", 19200, "port baud rate (bps)")
 	flag.IntVar(&value, "value", -1, "value to encode into a frame and send")
 	flag.UintVar(&minValue, "min-value", 1600, "minimum value that is valid (uint16)")
 	flag.UintVar(&maxValue, "max-value", 4400, "maximum value that is valid (uint16)")
@@ -48,62 +47,39 @@ func main() {
 
 	port, err := serial.Open(options)
 	if err != nil {
-		log.Fatalf("failed to open port %s: %v\n", portName, err)
+		log.Printf("failed to open port %s: %v\n", portName, err)
+		return
 	}
 	defer port.Close()
 
 	if value == -1 {
 		fmt.Println("stop because -1 entered")
-		os.Exit(0)
+		return
 	}
 
 	if value < int(minValue) {
-		log.Fatalf("error: %d is smaller than %d\n", value, minValue)
+		log.Printf("warning: %d is smaller than %d\n", value, minValue)
 	}
 
 	if value > int(maxValue) {
-		log.Fatalf("error: %d is bigger than max value %d\n", value, maxValue)
+		log.Printf("warning: %d is bigger than max value %d\n", value, maxValue)
 	}
 
 	if value > 65535 {
-		log.Fatalf("error: %d overflows uint16\n", value)
+		log.Printf("error: %d overflows uint16\n", value)
+		return
 	}
 
 	inputByte := uint16(value)
-	data := []byte{byte(inputByte >> 8), byte(inputByte)} // TODO: Check whether correct
+	data := []byte{byte(inputByte >> 8), byte(inputByte)}
 	frame := frames.Create([]byte(frames.LidarHeader), data)
 
-	fmt.Printf("frame: %s\n", frame)
+	log.Printf("frame: %s\n", frame)
 	for i, currentByte := range frame {
-		fmt.Println("---")
-		fmt.Printf("%d %s will be sent\n", i, frames.DescribeByte(currentByte))
+		log.Printf("%d %s will be sent\n", i, frames.DescribeByte(currentByte))
 		_, err := port.Write([]byte{currentByte})
 		if err != nil {
-			log.Fatalf("%d byte: failed to write it to port: %v\n", i, err)
+			log.Printf("%d byte: failed to write it to port: %v\n", i, err)
 		}
-		fmt.Printf("%d byte: wrote it to port\n", i)
 	}
-
-	// FIXME: doesn't work – output always contains only zeros
-	if waitForResponse {
-		fmt.Printf("waiting for 2 bytes...\n")
-		output := make([]byte, 2)
-		n, err := port.Read(output)
-		if err != nil {
-			log.Fatalln("failed to read from port:", err)
-		}
-		fmt.Printf("read %d bytes from port\n", n)
-
-		var fullValue uint16
-		fullValue = uint16(output[0]) << 8
-		fullValue += uint16(output[1])
-
-		for i, b := range output {
-			fmt.Printf("%d %s\n", i, frames.DescribeByte(b))
-		}
-
-		fmt.Printf("full value (uint16): %d\n", fullValue)
-	}
-
-	fmt.Println("stop")
 }


### PR DESCRIPTION
- remove error when the given value does not belong to the [min, max] range. It is useful especially because our range is not perfect.
- use `Print` instead of `Fatal`/`Panic` because we do not want to kill the program immediately.
- simplify byte-by-byte output - if there are no errors, a single byte prints a single line.
- use `servoctl` prefix everywhere.
- change the default baudrate to 19200